### PR TITLE
Remove `pydevd-pycharm` from Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM qgis/qgis:latest
-RUN pip install --no-cache-dir pytest-qgis pydevd-pycharm
+RUN pip install --no-cache-dir pytest-qgis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM qgis/qgis:latest
-RUN pip install --no-cache-dir pytest-qgis
+RUN pip install --no-cache-dir --break-system-packages pytest-qgis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
-version: '3.5'
-
 services:
-  qgis:
+  qgis-docker:
     build:
       dockerfile: Dockerfile
-    image: img_app:tag
+    image: qgis-for-pptl:ci
     container_name: qgis_pptl
     volumes:
     - type: bind
@@ -13,3 +11,4 @@ services:
     environment:
     - PYTHONPATH=/pptl
     - PPTL_TEST=1
+    command: tail -f /dev/null


### PR DESCRIPTION
Renamed the service and image in docker-compose for clarity. Updated the Dockerfile to include `--break-system-packages` in pip install for compatibility. Added a default command in the service to keep the container running.
It will solve errors related to the new Docker qgis images.