### PR TITLE
Update PR workflow badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![PR Validation](https://github.com/Elfpkck/polygons_parallel_to_line/actions/workflows/test.yaml/badge.svg)](https://github.com/Elfpkck/polygons_parallel_to_line/actions/workflows/test.yaml)
+[![PR Validation](https://github.com/Elfpkck/polygons_parallel_to_line/actions/workflows/test.yaml/badge.svg?event=pull_request
+)](https://github.com/Elfpkck/polygons_parallel_to_line/actions/workflows/test.yaml)
 # Polygons Parallel to Line
 ## General description and demonstration
 Depending on the settings, the plugin rotates the polygons in such a way that


### PR DESCRIPTION
Adjusted the PR validation badge URL to include the `event=pull_request`
 query parameter. This ensures the badge accurately reflects the status
 of pull request events.