### PR TITLE
Add Codecov Test Analytics

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,11 @@ jobs:
         slug: Elfpkck/polygons_parallel_to_line
         fail_ci_if_error: false
         override_branch: main
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
     - name: Cleanup
       if: always()
       run: make clean

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /.coverage
 /coverage.xml
+/junit.xml

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 	docker exec -t qgis_pptl sh -c "cd /pptl && poetry run pytest /pptl/tests --qgis_disable_gui"
 
 test-coverage:
-	docker exec -t qgis_pptl sh -c "cd /pptl && poetry run pytest /pptl/tests --qgis_disable_gui --cov=/pptl --cov-report=term-missing:skip-covered --cov-report=xml:/pptl/coverage.xml"
+	docker exec -t qgis_pptl sh -c "cd /pptl && poetry run pytest /pptl/tests --qgis_disable_gui --cov=/pptl --cov-report=term-missing:skip-covered --cov-report=xml:/pptl/coverage.xml --junitxml=/pptl/junit.xml -o junit_family=legacy"
 
 stop:
 	docker stop qgis_pptl


### PR DESCRIPTION
Integrates Codecov to upload test results and updates the workflow to include JUnit XML output. Adjusts the Makefile's test-coverage command to generate JUnit-compatible test reports and updates .gitignore to exclude junit.xml.