### PR TITLE
Use `QMetaType.Int` instead of `QVariant.Int` for `QgsField.type`

### DIFF
--- a/polygons_parallel_to_line/src/algorithm.py
+++ b/polygons_parallel_to_line/src/algorithm.py
@@ -13,7 +13,7 @@ from qgis.core import (
     QgsProcessingParameterFeatureSource,
     QgsProcessingParameterNumber,
 )
-from qgis.PyQt.QtCore import QVariant  # type: ignore
+from qgis.PyQt.QtCore import QMetaType  # type: ignore
 
 from .pptl import Params, PolygonsParallelToLine
 
@@ -103,7 +103,7 @@ class Algorithm(QgsProcessingAlgorithm):
             if self.COLUMN_NAME == field.name():
                 continue
             new_fields.append(field)
-        new_fields.append(QgsField(self.COLUMN_NAME, QVariant.Int))
+        new_fields.append(QgsField(self.COLUMN_NAME, QMetaType.Int))
         sink, dest_id = self.parameterAsSink(
             parameters,
             self.OUTPUT_LAYER,


### PR DESCRIPTION
Replaced the deprecated `QVariant.Int` with `QMetaType.Int` in the field type definition. This ensures compatibility with the underlying QGIS Python API and avoids potential future issues.