### PR TITLE
Add pip support to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,18 @@ updates:
       - "Elfpkck"
     labels:
       - "ci"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "03:15"
+      timezone: "UTC"
+    reviewers:
+      - "Elfpkck"
+    assignees:
+      - "Elfpkck"
+    labels:
+      - "dependencies"
+    allow:
+      - dependency-type: "direct"  # only update explicitly defined dependencies


### PR DESCRIPTION
This commit extends the Dependabot configuration to include Python (pip)
 dependencies. Updates are scheduled monthly at 03:15 UTC, targeting
 only direct dependencies. Configuration includes reviewers, assignees,
 and appropriate labels for better tracking.