### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: PR Validation
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Elfpkck/polygons_parallel_to_line/security/code-scanning/1](https://github.com/Elfpkck/polygons_parallel_to_line/security/code-scanning/1)

The fix involves specifying the minimum necessary permissions for the workflow by adding a top-level `permissions` section in the `.github/workflows/test.yaml` file. Since both shown jobs do not appear to require anything other than read access to the repository content (they do not push, create issues, comment, etc., and result uploads are handled by Codecov tokens), the correct fix is to add
```
permissions:
  contents: read
```
just below the `name:` and before `on:` keys at the top of the file. This ensures all jobs in the workflow start with the minimum set of permissions.

No other code, imports, or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
