### PR TITLE
Refactor: strip docstrings, simplify modules, fix no_multi regression

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,28 +29,29 @@ These instructions are specific to PyCharm.
 ### Docker Remote Debugging
 
 1. Perform the additional setup for the Python Debug Server:
-    - Path mappings: `/Users/elf/dev/private/polygons_parallel_to_line=/pptl`
-2. Uncomment the following line in `test_main_functionality.py`:
+    - Path mappings: `<absolute/path/to/repo>=/pptl` (replace the left side with your local clone's absolute path)
+2. Uncomment the following line in `tests/test_main_functionality.py`:
     ```python
     # pydevd_pycharm.settrace("host.docker.internal", port=53100, stdoutToServer=True, stderrToServer=True)
     ```
-3. Add `import pydevd_pycharm` to `test_main_functionality.py`.
+3. Add `import pydevd_pycharm` to `tests/test_main_functionality.py`.
 
 ### QGIS Remote Debugging
 
-1. Run:
+1. Install `pydevd-pycharm` and `pydevd` into the Python interpreter bundled with QGIS. On macOS:
     ```shell
     /Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install pydevd-pycharm pydevd
     ```
-2. Uncomment the following line in `pptl.py`:
+    On Linux/Windows, invoke `pip` from the QGIS-bundled Python (e.g., the `python3` shipped under the QGIS install directory).
+2. Uncomment the following line in `PolygonsParallelToLine/src/pptl.py`:
     ```python
     # pydevd_pycharm.settrace("127.0.0.1", port=53100, stdoutToServer=True, stderrToServer=True)
     ```
-3. Add `import pydevd_pycharm` to `pptl.py`.
+3. Add `import pydevd_pycharm` to `PolygonsParallelToLine/src/pptl.py`.
 4. In QGIS, navigate to Preferences → System → Environment, and add the following variable:
     - Apply: Append
     - Variable: `QGIS_PLUGINPATH`
-    - Value: `/path/to/plugin` (e.g., `/Users/elf/dev/private/polygons_parallel_to_line`)
+    - Value: `<absolute/path/to/repo>` (the absolute path to your local clone of this repository)
 5. To reload the plugin, use the "Plugin Reloader" plugin.
 
 ## Add a New Plugin Version to QGIS

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,41 @@
-.PHONY: build run test stop clean
+QGIS_VERSION ?= 3.44.7
+IMAGE := qgis-for-pptl:$(QGIS_VERSION)
+CONTAINER := qgis_pptl
+
+.PHONY: build run install install-dev test test-coverage stop clean
 
 build:
-	DOCKER_SCAN_SUGGEST=false docker build -t qgis-for-pptl:ci -f Dockerfile .
+	DOCKER_SCAN_SUGGEST=false docker build -t $(IMAGE) -f Dockerfile .
 
 # -v /pptl/.venv - an anonymous volume, which "shadows" the host's `.venv` directory
-run:
-	docker run -d --name qgis_pptl \
-		-v "$(shell pwd):/pptl" \
+# --rm: container is auto-removed on stop so `make run` is idempotent across sessions
+run: build
+	docker run -d --rm --name $(CONTAINER) \
+		-v "$(CURDIR):/pptl" \
 		-v /pptl/.venv \
 		-e PYTHONPATH=/pptl \
-		qgis-for-pptl:ci
+		$(IMAGE)
 
 install:
-	docker exec -t qgis_pptl sh -c "cd /pptl && uv venv --allow-existing --system-site-packages && uv sync --locked --no-dev"
+	docker exec $(CONTAINER) sh -c "cd /pptl && uv venv --allow-existing --system-site-packages && uv sync --locked --no-dev"
 
 # For an unknown reason, I need to add the pydevd package in this specific way to make the PyCharm remote debugger work with Docker
 install-dev:
-	docker exec -t qgis_pptl sh -c "cd /pptl && uv venv --allow-existing --system-site-packages && uv sync --locked && uv pip install pydevd"
+	docker exec $(CONTAINER) sh -c "cd /pptl && uv venv --allow-existing --system-site-packages && uv sync --locked && uv pip install pydevd"
 
 test:
-	docker exec -t qgis_pptl sh -c "cd /pptl && uv run --no-dev pytest /pptl/tests --qgis_disable_gui"
+	docker exec $(CONTAINER) sh -c "cd /pptl && uv run --no-dev pytest /pptl/tests --qgis_disable_gui"
 
 test-coverage:
-	docker exec -t qgis_pptl sh -c "cd /pptl && uv run --no-dev pytest /pptl/tests \
+	docker exec $(CONTAINER) sh -c "cd /pptl && uv run --no-dev pytest /pptl/tests \
 		--qgis_disable_gui \
-		--cov=/pptl \
+		--cov=/pptl/PolygonsParallelToLine/src \
 		--cov-report=term-missing:skip-covered \
 		--cov-report=xml:/pptl/coverage.xml \
 		--junitxml=/pptl/junit.xml -o junit_family=legacy"
 
 stop:
-	docker stop qgis_pptl
+	-docker stop $(CONTAINER)
 
 clean: stop
-	docker rm qgis_pptl
+	-docker rm $(CONTAINER)

--- a/PolygonsParallelToLine/metadata.txt
+++ b/PolygonsParallelToLine/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=Polygons Parallel to Line
-qgisMinimumVersion=3.0
+qgisMinimumVersion=3.22
 description=This plugin rotates polygons parallel to lines
 version=1.1
 author=Andrii Liekariev

--- a/PolygonsParallelToLine/src/algorithm.py
+++ b/PolygonsParallelToLine/src/algorithm.py
@@ -26,29 +26,6 @@ if TYPE_CHECKING:
 
 
 class Algorithm(QgsProcessingAlgorithm):
-    """
-    Class for rotating polygons to align with lines in a vector layer.
-
-    This class provides an implementation for a QGIS processing algorithm that rotates polygon features in a given
-    vector layer to be parallel to features in another line vector layer. It includes functionality to customize
-    the rotation parameters such as angle limits, distance thresholds, and handling of multipolygons.
-
-    :ivar OUTPUT_LAYER: Output ID for the sink layer where rotated polygons will be stored.
-    :type OUTPUT_LAYER: str
-    :ivar LINE_LAYER: Input ID for the line vector layer used for alignment.
-    :type LINE_LAYER: str
-    :ivar POLYGON_LAYER: Input ID for the polygon vector layer to rotate.
-    :type POLYGON_LAYER: str
-    :ivar LONGEST: Parameter ID for specifying whether to use the longest polygon segment for rotation.
-    :type LONGEST: str
-    :ivar NO_MULTI: Parameter ID for specifying whether to exclude multipolygons from rotation.
-    :type NO_MULTI: str
-    :ivar DISTANCE: Parameter ID for specifying the distance threshold from the line.
-    :type DISTANCE: str
-    :ivar ANGLE: Parameter ID for specifying the maximum angle for rotation.
-    :type ANGLE: str
-    """
-
     OUTPUT_LAYER = "OUTPUT"
     LINE_LAYER = "LINE_LAYER"
     POLYGON_LAYER = "POLYGON_LAYER"
@@ -116,43 +93,14 @@ class Algorithm(QgsProcessingAlgorithm):
         )
 
     def _create_output_fields(self, source_layer: QgsProcessingFeatureSource) -> QgsFields:
-        """
-        Creates output fields by appending a specific field if it does not already exist.
-
-        This function retrieves the fields from the input source layer, checks if a field with the specified name
-        exists, and appends it if missing. The new field has a Boolean type. The resulting set of fields is then
-        returned.
-
-        :param source_layer: The input source layer from which fields are retrieved.
-        :type source_layer: QgsProcessingFeatureSource
-        :return: The updated fields containing the original fields and the new field, if added.
-        :rtype: QgsFields
-        """
         fields = source_layer.fields()
-        field_idx = fields.indexFromName(COLUMN_NAME)
-        if field_idx == -1:
+        if fields.indexFromName(COLUMN_NAME) == -1:
             fields.append(QgsField(COLUMN_NAME, QMetaType.Bool))
-
         return fields
 
     def processAlgorithm(  # noqa: N802
         self, parameters: dict[str, Any], context: QgsProcessingContext, feedback: QgsProcessingFeedback
     ) -> dict[str, str]:
-        """
-        Executes the algorithm logic for processing geospatial data to create polygons parallel
-        to a given line based on specified parameters.
-
-        This function processes input geospatial layers, extracts relevant parameters, and applies
-        algorithms to produce new geometries. The result is saved as a new output layer.
-
-        :param parameters: A dictionary containing input parameters required to run the algorithm.
-                           It includes input layers, boolean flags, and numerical values.
-        :param context: An instance of QgsProcessingContext representing the execution context of the algorithm.
-                        It provides details such as layer sources and environment settings.
-        :param feedback: An instance of QgsProcessingFeedback used for logging progress, status, and errors
-                         encountered during processing.
-        :return: A dictionary containing the identifier of the created output layer.
-        """
         polygon_layer = self.parameterAsSource(parameters, self.POLYGON_LAYER, context)
         output_fields = self._create_output_fields(polygon_layer)
         sink, dest_id = self.parameterAsSink(

--- a/PolygonsParallelToLine/src/azimuth.py
+++ b/PolygonsParallelToLine/src/azimuth.py
@@ -2,18 +2,6 @@ from __future__ import annotations
 
 
 def normalize_azimuth_to_positive_range(azimuth: float) -> float:
-    """
-    Normalize an azimuth value to the positive range [0, 180].
-
-    The function takes an azimuth value, which represents an angle in degrees, and ensures that it is expressed in its
-    positive range. If the azimuth is exactly -180, it is converted to 180. If the azimuth is negative but not -180,
-    the function adjusts the value to ensure it falls within the positive range of 0 to 180 degrees.
-
-    :param azimuth: The input angle in degrees that needs to be normalized.
-    :type azimuth: float
-    :return: The normalized azimuth value in the range [0, 180].
-    :rtype: float
-    """
     if azimuth == -180:
         azimuth = 180
     elif azimuth < 0:
@@ -22,17 +10,6 @@ def normalize_azimuth_to_positive_range(azimuth: float) -> float:
 
 
 def normalize_azimuth_to_90_range(azimuth: float) -> float:
-    """
-    Normalize the provided azimuth angle to fall within the range of -90 to 90 degrees.
-
-    This function takes an azimuth angle and adjusts it to ensure it resides within the range of -90 to 90 degrees.
-    Positive azimuth angles greater than 90 are reduced by 180, and negative azimuth angles less than -90 are increased
-    by 180 to keep them in the specified range.
-
-    :param azimuth: The azimuth angle in degrees to be normalized. Expected to be a floating-point value.
-    :return: The normalized azimuth angle within the range of -90 to 90 degrees.
-    :rtype: float
-    """
     if azimuth > 90:
         azimuth -= 180
     elif azimuth < -90:
@@ -41,16 +18,6 @@ def normalize_azimuth_to_90_range(azimuth: float) -> float:
 
 
 def calc_delta_azimuth(segment_azimuth: float, line_azimuth: float) -> float:
-    """
-    Calculates the delta azimuth between a given segment azimuth and a line azimuth. The delta azimuth is normalized
-    to fit within the range of -90 to +90 degrees.
-    This function uses helper functions to normalize the azimuth values before computing the difference.
-
-    :param segment_azimuth: Azimuth angle of the segment in degrees
-    :param line_azimuth: Azimuth angle of the reference line in degrees
-    :return: Normalized delta azimuth in degrees within -90 to +90 range
-    :rtype: float
-    """
     return normalize_azimuth_to_90_range(
         normalize_azimuth_to_positive_range(segment_azimuth) - normalize_azimuth_to_positive_range(line_azimuth)
     )

--- a/PolygonsParallelToLine/src/const.py
+++ b/PolygonsParallelToLine/src/const.py
@@ -1,6 +1,1 @@
-"""
-Constants:
-    COLUMN_NAME: Name of the attribute column used to store rotation status for each feature.
-"""
-
 COLUMN_NAME = "_rotated"

--- a/PolygonsParallelToLine/src/line.py
+++ b/PolygonsParallelToLine/src/line.py
@@ -1,13 +1,3 @@
-"""
-Represents a utility for processing lines, line layers, and geometric segments in GIS.
-
-This module defines three primary classes for working with lines and geometrical relationships in a GIS context.
-The `Line` class facilitates operations on individual line geometries, such as finding the closest segment to a
-given point. The `LineLayer` class is designed to handle spatial queries and mapping for layers of line
-geometries, leveraging spatial indexing for efficiency. Finally, the `Segment` class models straight-line
-segments with additional properties like length and azimuth calculated on demand.
-"""
-
 from __future__ import annotations
 
 from functools import cached_property
@@ -26,85 +16,22 @@ if TYPE_CHECKING:
 
 
 class Line:
-    """
-    Represents a line object with associated geometry and feature.
-
-    This class is a utility for working with line geometries, particularly for calculating distances and finding the
-    closest segment to a given point. It is initialized with a QgsFeature object that contains the geometry of the line.
-
-    :ivar feature: The QgsFeature object representing the line.
-    :type feature: QgsFeature
-    :ivar geom: The QgsGeometry object derived from the feature.
-    :type geom: QgsGeometry
-    """
-
     def __init__(self, line_feature: QgsFeature):
-        self.feature: QgsFeature = line_feature
         self.geom: QgsGeometry = line_feature.geometry()
 
     def get_closest_segment(self, point_xy: QgsPointXY) -> Segment:
-        """
-        Finds and returns the closest line segment to a given point within a geometry.
-
-        :param point_xy: The point for which the closest segment is to be determined.
-        :type point_xy: QgsPointXY
-        :return: A segment object defining the closest line segment with its start and end points.
-        :rtype: Segment
-        """
         _, _, next_vertex_idx, _ = self.geom.closestSegmentWithContext(point_xy)
         start, end = self.geom.vertexAt(next_vertex_idx - 1), self.geom.vertexAt(next_vertex_idx)
         return Segment(start=start, end=end)
 
-    def calc_distance(self, geom: QgsGeometry) -> float:
-        """
-        Calculates the distance between the geometry of the current object and another geometry.
-
-        The function computes the shortest distance between the two geometries and returns it as a floating-point value.
-
-        :param geom: The geometry object to compute the distance to.
-        :type geom: QgsGeometry
-        :return: The shortest distance between the current object's geometry and the given geometry.
-        :rtype: float
-        """
-        return self.geom.distance(geom)
-
 
 class LineLayer:
-    """
-    Represents a handler for processing line layers and performing efficient spatial queries. It manages a mapping of
-    line feature IDs to their corresponding features and a spatial index to facilitate quick geometric operations.
-
-    This class is particularly useful for operations requiring proximity-based queries
-    or access to specific line features by ID.
-
-    :ivar line_layer: The input line layer provided during initialization.
-    :type line_layer: QgsProcessingFeatureSource
-    :ivar id_line_map: A dictionary that maps each feature's ID to its corresponding QgsFeature for quick lookup.
-    :type id_line_map: dict[int, QgsFeature]
-    :ivar spatial_index: A spatial index initialized with the line features to enable efficient spatial queries.
-    :type spatial_index: QgsSpatialIndex
-    """
-
     def __init__(self, line_layer: QgsProcessingFeatureSource):
-        self.line_layer = line_layer
         self.id_line_map: dict[int, QgsFeature] = {x.id(): x for x in line_layer.getFeatures()}
         self.spatial_index = QgsSpatialIndex(flags=QgsSpatialIndex.FlagStoreFeatureGeometries)
-        self.spatial_index.addFeatures(line_layer.getFeatures())
+        self.spatial_index.addFeatures(self.id_line_map.values())
 
     def get_closest_line(self, point: QgsPointXY) -> Line:
-        """
-        Find the closest line to a given point using a spatial index.
-
-        This function identifies the nearest line to a specified point using a spatial index. The function will raise
-        an exception if no lines are found near the provided point. Once the nearest line is detected, it is retrieved
-        from the ID-line mapping and returned.
-
-        :param point: The geographical point for which the closest line is to be determined.
-        :type point: QgsPointXY
-        :return: The closest line to the specified point.
-        :rtype: Line
-        :raises QgsProcessingException: If no lines are found near the given point.
-        """
         closest_line_id = self.spatial_index.nearestNeighbor(point, 1)
 
         if not closest_line_id:
@@ -115,46 +42,15 @@ class LineLayer:
 
 
 class Segment:
-    """
-    Represents a geometric segment defined by a start and an end point.
-
-    The Segment class models a straight line between two points and provides properties for accessing various
-    characteristics of the segment such as its length and azimuth.
-
-    :ivar start: The starting point of the segment.
-    :type start: QgsPoint
-    :ivar end: The ending point of the segment.
-    :type end: QgsPoint
-    """
-
     def __init__(self, start: QgsPoint, end: QgsPoint):
         self.start = start
         self.end = end
 
     @cached_property
     def length(self) -> float:
-        """
-        Computes the length of a geometric segment defined by start and end points.
-
-        The `length` is calculated lazily upon access using the `distance` method of the `start` point with respect to
-        the `end` point. The result is cached after the first computation.
-
-        :return: The computed length between the start and end points.
-        :rtype: float
-        """
         return self.start.distance(self.end)
 
     @cached_property
     def azimuth(self) -> float:
-        """
-        Represents a cached property that calculates the azimuth between two points.
-
-        The azimuth is computed lazily based on the starting and ending points, which are expected to have an `azimuth`
-        method. The result is cached after the first computation, so subsequent accesses do not require recalculation.
-
-        QgsPoint.azimuth(QgsPoint) returns the azimuth between two points in a range of -180 to 180 degrees.
-
-        :return: The azimuth computed between the start and end points.
-        :rtype: float
-        """
+        # QgsPoint.azimuth returns -180..180
         return self.start.azimuth(self.end)

--- a/PolygonsParallelToLine/src/plugin.py
+++ b/PolygonsParallelToLine/src/plugin.py
@@ -1,16 +1,8 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 from qgis.core import QgsApplication
 
 from .provider import Provider
-
-cmd_folder = str(Path(__file__).parents[1])
-
-if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)
 
 
 class Plugin:

--- a/PolygonsParallelToLine/src/polygon.py
+++ b/PolygonsParallelToLine/src/polygon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from qgis.core import Qgis, QgsGeometry, QgsProcessingException
@@ -13,64 +14,24 @@ if TYPE_CHECKING:
 
 
 class Polygon:
-    """
-    Represents a polygon geometry and provides methods to perform various geometric operations such as
-    retrieving vertices, adjacent segments, and applying rotations.
-
-    This class encapsulates a polygon feature from a geographic dataset using the `QgsFeature` and `QgsGeometry`
-    structures provided by QGIS. It exposes information about the polygon, such as its geometric representation,
-    whether it is multipart, its centroid, and its rotation status.
-
-    :ivar feature: The underlying QGIS feature representing the polygon.
-    :type feature: QgsFeature
-    :ivar geom: The geometry of the polygon derived from the feature.
-    :type geom: QgsGeometry
-    :ivar is_multi: Boolean indicating whether the polygon is multipart.
-    :type is_multi: bool
-    :ivar center_xy: The centroid of the polygon in x-y coordinates.
-    :type center_xy: QgsPointXY
-    :ivar is_rotated: Boolean indicating if the polygon has been rotated.
-    :type is_rotated: bool
-    """
-
     def __init__(self, polygon_feature: QgsFeature):
         self.feature = polygon_feature
         self.geom: QgsGeometry = polygon_feature.geometry()
         self.is_multi: bool = self.geom.isMultipart()
-        self.center_xy: QgsPointXY = self.geom.centroid().asPoint()
         self.is_rotated: bool = False
 
-    def get_closest_vertex(self, closest_line: Line) -> QgsPoint:
-        """
-        Computes the closest vertex on the geometry associated with the calling object to a specified line geometry.
-        The computation identifies the point on the line geometry nearest to the geometry of the calling object, and
-        subsequently retrieves the closest vertex on the calling object's geometry to that point.
+    @cached_property
+    def center_xy(self) -> QgsPointXY:
+        return self.geom.centroid().asPoint()
 
-        :param closest_line: The line geometry which shall be used to determine the closest vertex on the geometry of
-            the calling object.
-        :return: A QgsPoint object representing the closest vertex on the geometry of the calling object to
-            the nearest point on the specified line geometry.
-        """
+    def get_closest_vertex(self, closest_line: Line) -> QgsPoint:
         nearest_point_on_line_geom = closest_line.geom.nearestPoint(self.geom)
         _, closest_vertex_idx = self.geom.closestVertexWithContext(nearest_point_on_line_geom.asPoint())
         return self.geom.vertexAt(closest_vertex_idx)
 
     def get_adjacent_segments(self, target_vertex: QgsPoint) -> tuple[Segment, Segment]:
-        """
-        Finds and retrieves the two segments adjacent to a given vertex within a geometry.
-
-        The method processes the geometry associated with a feature by cleaning it up, removing interior rings as
-        well as duplicate nodes, and then checking each geometry part for adjacency to the provided target vertex.
-        It identifies the indices of the vertices adjacent to the target vertex and constructs the corresponding
-        segments.
-
-        :param target_vertex: The vertex for which the adjacent segments need to be determined, represented as a
-            QgsPoint.
-        :return: A tuple containing two Segment objects. Each Segment represents a start and end vertex adjacent to
-            the passed target_vertex.
-        :rtype: tuple[Segment, Segment]
-        :raises QgsProcessingException: If the target_vertex is not found within the geometry of the feature.
-        """
+        # Strip interior rings and duplicate nodes on a copy so they don't influence the
+        # rotation pivot; the original geom is preserved for the actual rotate.
         temp_geom = QgsGeometry(self.geom)
         temp_geom.removeInteriorRings()
         temp_geom.removeDuplicateNodes()
@@ -87,24 +48,9 @@ class Polygon:
         msg = f"Vertex {target_vertex} not found in polygon {self.feature.id()}"
         raise QgsProcessingException(msg)
 
-    def rotate(self, angle: float) -> Qgis.GeometryOperationResult:
-        """
-        Rotates the geometry of the feature around a specified center point.
-
-        The method performs a rotation operation on the geometry of the associated feature by the specified angle. If
-        the rotation is successfully completed, the geometry of the feature is updated, and the rotation status is set.
-
-        QgsGeometry.rotate() takes any positive and negative values. Positive - rotate clockwise,
-        negative - counterclockwise.
-
-        :param angle: The angle, in degrees, by which the geometry will be rotated.
-        :type angle: float
-        :return: The result of the geometry rotation operation, indicating success or failure.
-        :rtype: Qgis.GeometryOperationResult
-        """
+    def rotate(self, angle: float) -> None:
+        # QgsGeometry.rotate: positive angle = clockwise, negative = counterclockwise.
         result = self.geom.rotate(angle, self.center_xy)
         if result == Qgis.GeometryOperationResult.Success:
             self.feature.setGeometry(self.geom)
             self.is_rotated = True
-
-        return result

--- a/PolygonsParallelToLine/src/pptl.py
+++ b/PolygonsParallelToLine/src/pptl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from qgis.core import (
@@ -22,31 +23,6 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class Params:
-    """
-    Represents the parameters for processing geospatial data.
-
-    This class defines a set of parameters required for processing geospatial data, such as line and polygon layers,
-    adjustable distance, angle parameters, and options to control output formats and behavior. It acts as a container
-    for inputs and configurations necessary for geospatial processing workflows.
-
-    :ivar line_layer: A feature source representing the input line layer.
-    :type line_layer: QgsProcessingFeatureSource
-    :ivar polygon_layer: A feature source representing the input polygon layer.
-    :type polygon_layer: QgsProcessingFeatureSource
-    :ivar by_longest: Determines whether processing should consider the longest feature during calculations.
-    :type by_longest: bool
-    :ivar no_multi: Determines whether to restrict outputs to single-part geometries (no multiparts).
-    :type no_multi: bool
-    :ivar distance: A numeric value representing a distance parameter within the process.
-    :type distance: float
-    :ivar angle: A numeric value representing an angle parameter for calculations.
-    :type angle: float
-    :ivar fields: A collection of feature fields to be processed.
-    :type fields: QgsFields
-    :ivar sink: A feature sink where processed output features are stored.
-    :type sink: QgsFeatureSink
-    """
-
     line_layer: QgsProcessingFeatureSource
     polygon_layer: QgsProcessingFeatureSource
     by_longest: bool
@@ -58,40 +34,16 @@ class Params:
 
 
 class PolygonsParallelToLine:
-    """
-    Handles the processing of polygons to align them parallel to the closest line from a provided line layer.
-
-    This class is designed to process polygons from a given layer, validate their existence, and rotate them to align
-    parallel to the nearest line within a specified line layer. The class operates based on provided parameters which
-    define constraints and criteria for processing, such as distance thresholds, rotation angles, and multi-polygon
-    behavior.
-
-    The processing includes validating the input polygon layer, determining the closest line for each polygon,
-    calculating necessary rotations, applying transformations, and saving the processed features into the sink layer.
-
-    :ivar feedback: The QgsProcessingFeedback object used for sending feedback to the user during processing,
-        such as progress updates.
-    :type feedback: QgsProcessingFeedback
-    :ivar params: The object encapsulating all parameters required for processing the polygons, such as layers to
-        process, fields, and constraints.
-    :type params: Params
-    :ivar total_number: The total number of features (polygons) in the input layer being processed.
-    :type total_number: int
-    """
-
     def __init__(self, feedback: QgsProcessingFeedback, params: Params):
         self.feedback = feedback
         self.params = params
         self.total_number: int = self.params.polygon_layer.featureCount()
 
-    def run(self) -> None:
-        """
-        Executes the main functionality of the object, involving validation and manipulation of polygon-related data.
-        The function performs a series of predefined operations critical to the object's intended behavior.
-        Specifically, it validates a polygon layer and applies a rotation operation to the polygons.
+    @cached_property
+    def line_layer(self) -> LineLayer:
+        return LineLayer(self.params.line_layer)
 
-        :return: None
-        """
+    def run(self) -> None:
         # pydevd_pycharm.settrace("127.0.0.1", port=53100, stdoutToServer=True, stderrToServer=True) # noqa: ERA001
         self.validate_polygon_layer()
         self.rotate_polygons()
@@ -102,16 +54,6 @@ class PolygonsParallelToLine:
             raise QgsProcessingException(msg)
 
     def rotate_polygons(self) -> None:
-        """
-        Rotates and processes polygons from the provided layer and updates the progress feedback. The method iterates
-        through the features in the polygon layer, processes each polygon, and adds the processed features to
-        the designated sink. Progress is updated during each iteration, and the operation stops if it is canceled via
-        feedback.
-
-        :param self: An instance of the class the method belongs to.
-
-        :returns: None
-        """
         total = 100.0 / self.total_number
 
         for i, polygon in enumerate(self.params.polygon_layer.getFeatures(), start=1):
@@ -123,21 +65,15 @@ class PolygonsParallelToLine:
             self.feedback.setProgress(int(i * total))
 
     def process_polygon(self, polygon: QgsFeature) -> QgsFeature:
-        """
-        Processes a polygon by calculating its proximity to the closest line, applying various transformations and
-        conditions, and creating a new feature based on the modifications or conditions provided.
-
-        :param polygon: The QgsFeature object representing the input polygon to be processed.
-        :type polygon: QgsFeature
-        :return: A QgsFeature object representing the newly processed or modified polygon.
-        :rtype: QgsFeature
-        """
         poly = Polygon(polygon)
-        line_layer = LineLayer(self.params.line_layer)
-        closest_line = line_layer.get_closest_line(poly.center_xy)
-        distance = closest_line.calc_distance(poly.geom)
 
-        if (self.params.distance and distance > self.params.distance) or (self.params.no_multi and poly.is_multi):
+        if self.params.no_multi and poly.is_multi:
+            return self.create_new_feature(poly)
+
+        # Selected by centroid distance; an edge of the polygon may be nearer to a different line.
+        closest_line = self.line_layer.get_closest_line(poly.center_xy)
+
+        if self.params.distance and closest_line.geom.distance(poly.geom) > self.params.distance:
             return self.create_new_feature(poly)
 
         PolygonRotator(
@@ -149,19 +85,6 @@ class PolygonsParallelToLine:
         return self.create_new_feature(poly)
 
     def create_new_feature(self, poly: Polygon) -> QgsFeature:
-        """
-        Creates a new feature and sets its geometry and attribute based on the provided polygon.
-
-        This method creates a new QgsFeature using the provided fields, sets the geometry of the new feature to
-        match the geometry of the provided polygon, and assigns the attribute value to indicate whether the polygon
-        is rotated. The created QgsFeature is then returned.
-
-        :param poly: The polygon object whose geometry and rotation status are used to define the new feature's
-            properties.
-        :type poly: Polygon
-        :return: The newly created QgsFeature with its geometry and attributes set accordingly.
-        :rtype: QgsFeature
-        """
         new_feature = QgsFeature(self.params.fields)
         new_feature.setGeometry(poly.geom)
         new_feature.setAttribute(COLUMN_NAME, poly.is_rotated)

--- a/PolygonsParallelToLine/src/provider.py
+++ b/PolygonsParallelToLine/src/provider.py
@@ -11,14 +11,14 @@ if TYPE_CHECKING:
 
 
 class Provider(QgsProcessingProvider):
-    def loadAlgorithms(self, *args, **kwargs) -> None:
+    def loadAlgorithms(self) -> None:
         self.addAlgorithm(Algorithm())
 
-    def id(self, *args, **kwargs) -> str:
+    def id(self) -> str:
         return "pptl"
 
-    def name(self, *args, **kwargs) -> str:
+    def name(self) -> str:
         return "Polygons parallel to lines"
 
     def icon(self) -> QIcon:
-        return QgsProcessingProvider.icon(self)
+        return super().icon()

--- a/PolygonsParallelToLine/src/rotator.py
+++ b/PolygonsParallelToLine/src/rotator.py
@@ -13,32 +13,6 @@ if TYPE_CHECKING:
 
 
 class PolygonRotator:
-    """
-    Handles the behavior of rotating a polygon based on its segments and azimuth differences.
-
-    This class provides methods for determining and executing rotational adjustments on a polygon. The rotation logic
-    accounts for the relationship between a polygon's vertices, the adjacent segments, and the closest external line
-    segment. Decisions are based on calculated azimuth differences and configurable thresholds. Optional behavior
-    includes determining the rotation based on either the longest polygon segment or the smallest rotation angle.
-
-    :ivar poly: The polygon object to be rotated.
-    :type poly: Polygon
-    :ivar angle_threshold: The angle threshold used to determine valid rotations.
-    :type angle_threshold: float
-    :ivar by_longest: Indicates whether rotation should be based on the longest segment.
-    :type by_longest: bool
-    :ivar prev_poly_segment: The polygon segment preceding the closest vertex.
-    :type prev_poly_segment: Segment
-    :ivar next_poly_segment: The polygon segment following the closest vertex.
-    :type next_poly_segment: Segment
-    :ivar prev_delta_azimuth: The azimuth difference between the line segment and the previous polygon segment.
-    :type prev_delta_azimuth: float
-    :ivar next_delta_azimuth: The azimuth difference between the line segment and the next polygon segment.
-    :type next_delta_azimuth: float
-    :ivar ABSOLUTE_TOLERANCE: Tolerance value for numerical closeness comparison in rotation.
-    :type ABSOLUTE_TOLERANCE: float
-    """
-
     ABSOLUTE_TOLERANCE = 1e-8
 
     def __init__(self, poly: Polygon, closest_line: Line, angle_threshold: float, *, by_longest: bool):
@@ -52,51 +26,26 @@ class PolygonRotator:
         self.next_delta_azimuth = calc_delta_azimuth(line_segment.azimuth, self.next_poly_segment.azimuth)
 
     def rotate(self) -> None:
-        """
-        Rotates the object based on the specified conditions and angle thresholds.
+        prev_within = abs(self.prev_delta_azimuth) <= self.angle_threshold
+        next_within = abs(self.next_delta_azimuth) <= self.angle_threshold
 
-        The rotation logic depends on whether the azimuth differences, `prev_delta_azimuth` and `next_delta_azimuth`,
-        fall within the provided angle threshold. If the conditions are met, it either rotates by the longest segment
-        or by the smallest angle. It may also perform rotation based on the specific azimuth difference if only one
-        of them satisfies the threshold.
-
-        :return: None
-        """
-        if abs(self.prev_delta_azimuth) <= self.angle_threshold >= abs(self.next_delta_azimuth):
+        if prev_within and next_within:
             if self.by_longest:
-                return self.rotate_by_longest_segment()
-            return self.rotate_by_smallest_angle()
+                self.rotate_by_longest_segment()
+            else:
+                self.rotate_by_smallest_angle()
+            return
 
-        for delta_azimuth in (self.prev_delta_azimuth, self.next_delta_azimuth):
-            if abs(delta_azimuth) <= self.angle_threshold:
-                return self.rotate_by_angle(delta_azimuth)
+        if prev_within:
+            self.rotate_by_angle(self.prev_delta_azimuth)
+        elif next_within:
+            self.rotate_by_angle(self.next_delta_azimuth)
 
     def rotate_by_angle(self, angle: float) -> None:
-        """
-        Rotates a polygon by a specified angle if the angle is not close to zero.
-
-        This method checks if the provided angle is approximately zero using a tolerance value. If the angle is not
-        close to zero, the method applies a rotation transformation to the polygon.
-
-        :param angle: The angle, in degrees, by which the polygon should be rotated.
-        :type angle: float
-        :return: None
-        """
-        is_close_to_zero = math.isclose(angle, 0.0, abs_tol=self.ABSOLUTE_TOLERANCE)
-        if not is_close_to_zero:
+        if not math.isclose(angle, 0.0, abs_tol=self.ABSOLUTE_TOLERANCE):
             self.poly.rotate(angle)
 
     def rotate_by_longest_segment(self) -> None:
-        """
-        Rotates an object based on the lengths of the previous and next polygon segments.
-
-        The function compares the lengths of the previous polygon segment and the next polygon segment. If the previous
-        segment is longer, the rotation is performed using the previous azimuth delta. If the next segment is longer,
-        the rotation is performed using the next azimuth delta. In the case where both segments have the same length,
-        the rotation is executed based on the smallest rotational angle.
-
-        :return: None
-        """
         if self.prev_poly_segment.length > self.next_poly_segment.length:
             self.rotate_by_angle(self.prev_delta_azimuth)
         elif self.prev_poly_segment.length < self.next_poly_segment.length:
@@ -105,16 +54,6 @@ class PolygonRotator:
             self.rotate_by_smallest_angle()
 
     def rotate_by_smallest_angle(self) -> None:
-        """
-        Rotates the object by the smallest absolute angle difference.
-
-        It compares the absolute values of the previous and next azimuth deltas and invokes the rotation method with
-        the smaller magnitude delta.
-
-        :raises ValueError: Raises an exception if the rotation operation is invalid.
-        :return: This method returns nothing; it performs the operation of rotating the object using the appropriate
-            azimuth delta.
-        """
         if abs(self.prev_delta_azimuth) > abs(self.next_delta_azimuth):
             self.rotate_by_angle(self.next_delta_azimuth)
         else:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A QGIS processing plugin that automatically rotates polygons to align them paral
 
 ## Quick Start
 
-1. **Access the Plugin**: Go to **Processing** → **Toolbox** → **Polygons Parallel to Line**
+1. **Access the Plugin**: Go to **Processing** → **Toolbox** → **Polygons parallel to lines**
 2. **Select Input Layers**: Choose your polygon and line layers
 3. **Configure Parameters**: Set distance and angle thresholds as needed
 4. **Run**: Execute the algorithm to generate aligned polygons
@@ -50,40 +50,42 @@ A QGIS processing plugin that automatically rotates polygons to align them paral
 
 ## Features
 
-✅ **Automatic Polygon Rotation**: Intelligently rotates polygons to align with nearest lines  
+✅ **Automatic Polygon Rotation**: Rotates polygons to align with the nearest line  
 ✅ **Distance-based Filtering**: Optional maximum distance constraint  
-✅ **Angle Threshold Control**: Configurable rotation angle limits  
-✅ **Multigeometry Support**: Handles both simple and complex geometries  
-✅ **Rotation Tracking**: Adds `_rotated` field to track which polygons were modified  
-✅ **Geometry Validation**: Built-in checks for geometry integrity  
+✅ **Angle Threshold Control**: Configurable angle threshold that gates which polygons are rotated  
+✅ **Multipolygon Handling**: Multipolygons are processed (or can be skipped) — see Keynotes for behavior  
+✅ **Rotation Tracking**: Adds a `_rotated` boolean field marking which polygons were modified  
 
 ## Algorithm
 
 The plugin processes each polygon using the following steps:
 
-1. **Distance Check**: Calculates distance from polygon centroid to the nearest line
-   - If `Max distance from line` > 0 and distance exceeds a threshold → skip polygon
+1. **Closest Line Selection**: Finds the line whose feature is the nearest neighbor of the polygon centroid
 
-2. **Vertex Analysis**: Identifies the closest polygon vertex to the nearest line
+2. **Distance Check**: If `Max distance from line` > 0 and the polygon-to-line geometry distance (closest edge of the polygon to the closest line) exceeds it → skip rotation
 
-3. **Segment Evaluation**: Analyzes two adjacent segments of the closest vertex
+3. **Vertex Analysis**: Identifies the polygon vertex closest to the nearest line
 
-4. **Angle Calculation**: Computes rotation angles between line segment and polygon segments
+4. **Segment Evaluation**: Takes the two polygon segments adjacent to that vertex
 
-5. **Rotation Decision**:
-   - If both angles ≤ `Max angle`:
-     - **Longest segment mode**: Rotates based on longest segment (or smallest angle if equal)
-     - **Default mode**: Rotates based on the smallest angle
-   - If only one angle ≤ `Max angle`: Rotates based on that segment
+5. **Angle Calculation**: Computes the signed angle (delta azimuth) between the closest line segment and each adjacent polygon segment
 
-6. **Output Generation**: Creates rotated geometry with `_rotated` field indicator
+6. **Rotation Decision** (each delta is compared against `Max angle`):
+   - If both deltas are within `Max angle`:
+     - **Longest segment mode**: Rotates by the delta of the longer segment (falls back to smallest delta if lengths are equal)
+     - **Default mode**: Rotates by the smaller delta
+   - If only one delta is within `Max angle`: Rotates by that delta
+   - If neither delta is within `Max angle`: No rotation is applied
+   - Rotations whose magnitude is effectively zero are skipped (avoids spurious `_rotated=True`)
+
+7. **Output Generation**: Writes the (possibly rotated) geometry with a `_rotated` boolean attribute
 
 ![Default Usage][default_usage]
 
 ### Keynotes
-- Rotation center is the polygon centroid
-- Interior rings and duplicate vertices are ignored
-- Multipolygons use the same principles as simple polygons
+- Rotation center is the polygon centroid (for multipolygons: the overall centroid of the whole multi-geometry)
+- Interior rings and duplicate vertices are ignored when picking the rotation pivot, but they are preserved in the output geometry
+- Multipolygons are rotated as a single rigid body around the overall centroid by the angle chosen from the part that contains the closest vertex — individual parts are not aligned independently
 - The `_rotated` field indicates transformation status (boolean)
 
 ![Rotated Field][_rotated]
@@ -104,7 +106,7 @@ When set to 0.0, all polygons are processed regardless of distance.
 - **Type**: Float (optional)  
 - **Range**: 0.0 - 89.9 degrees
 - **Default**: 89.9
-- **Purpose**: Limits a maximum rotation angle
+- **Purpose**: Threshold on the angle between a polygon segment and the closest line segment. A polygon is only rotated when at least one of its two adjacent segments has a delta angle within this threshold; otherwise the polygon is left unrotated. The applied rotation is bounded by this threshold.
 
 ![Angle Configuration][angle]
 
@@ -118,7 +120,7 @@ When set to 0.0, all polygons are processed regardless of distance.
 ### Skip Multipolygons
 - **Type**: Boolean
 - **Default**: False
-- **Purpose**: Excludes multipolygon geometries from processing
+- **Purpose**: When enabled, multipolygon features are passed through to the output unchanged (with `_rotated=False`) instead of being rotated. They are not removed from the output layer.
 
 ## Usage Examples
 
@@ -140,7 +142,6 @@ When set to 0.0, all polygons are processed regardless of distance.
 - ✅ Windows
 - ✅ macOS  
 - ✅ Linux
-- ✅ All QGIS LTR versions
 
 ## Best Practices
 
@@ -163,9 +164,9 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed development setup and contribu
 
 ## License
 
-Copyright (C) 2016-2025 by Andrii Liekariev
+Copyright (C) 2016-2026 by Andrii Liekariev
 
-This project is licensed under the [GNU General Public License v2.0](LICENSE.txt).
+This project is licensed under the [GNU General Public License v2.0 or later](LICENSE.txt).
 
 ## Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ version = "1.1"
 
 [tool.coverage.report]
 exclude_also = [
-  "if TYPE_CHECKING",
-  "if cmd_folder not in sys.path"
+  "if TYPE_CHECKING"
 ]
 
 [tool.coverage.run]
@@ -47,6 +46,7 @@ ignore = [
   "D100",
   "D101",
   "D102",
+  "D103",
   "D104",
   "D107",
   "D205",
@@ -63,9 +63,9 @@ combine-as-imports = true
 force-sort-within-sections = true
 
 [tool.ruff.lint.per-file-ignores]
-"PolygonsParallelToLine/__init__.py" = ["ANN001", "ARG001", "D103", "N802", "PLC0415"]
+"PolygonsParallelToLine/__init__.py" = ["ANN001", "ARG001", "N802", "PLC0415"]
 "algorithm.py" = ["ARG002", "I001"]
 "azimuth.py" = ["PLR2004"]
 "plugin.py" = ["I001", "N802"]
-"provider.py" = ["ANN002", "ANN003", "ARG002", "N802"]
-"tests/*" = ["ANN001", "ANN201", "ARG001", "D103", "D413", "E501", "PLR0913", "PT003", "PT006", "S101"]
+"provider.py" = ["N802"]
+"tests/*" = ["ANN001", "ANN201", "ARG001", "D413", "E501", "PLR0913", "PT003", "PT006", "S101"]

--- a/tests/test_main_functionality.py
+++ b/tests/test_main_functionality.py
@@ -177,36 +177,38 @@ def test_main_functionality(
     assert [x[const.COLUMN_NAME] for x in output_layer.getFeatures()] == _rotated
 
 
+def test_no_multi_skips_multipolygons_when_line_layer_empty(qgis_processing, add_features):
+    # Regression: with no_multi=True, multipolygons must be skipped without touching the
+    # (empty) line layer; previously the line lookup ran first and would raise.
+    line_layer = QgsVectorLayer("linestring", "temp_line", "memory")
+
+    poly_layer = QgsVectorLayer("polygon", "temp_poly", "memory")
+    add_features(
+        vector_layer=poly_layer,
+        wkt_geometries=(
+            "MultiPolygon (((0 0, 1 0, 1 1, 0 1, 0 0)))",
+            "MultiPolygon (((10 10, 11 10, 11 11, 10 11, 10 10)))",
+        ),
+    )
+
+    params = {
+        "LINE_LAYER": line_layer,
+        "POLYGON_LAYER": poly_layer,
+        "LONGEST": False,
+        "NO_MULTI": True,
+        "DISTANCE": 0.0,
+        "ANGLE": 89.9,
+        "OUTPUT": QgsProcessingOutputLayerDefinition("TEMPORARY_OUTPUT"),
+    }
+    context = QgsProcessingContext()
+    result = processing.run(algOrName=Algorithm(), parameters=params, context=context)
+    output_layer = context.getMapLayer(result[Algorithm.OUTPUT_LAYER])
+
+    assert [x[const.COLUMN_NAME] for x in output_layer.getFeatures()] == [False, False]
+
+
 @pytest.fixture(scope="module")
 def add_features():
-    """
-    Pytest fixture that returns a function to add geometric features to a vector layer.
-
-    This session-scoped fixture provides a reusable function for adding multiple
-    geometric features to a QgsVectorLayer from WKT (Well-Known Text) geometry strings.
-    Useful for setting up test data in QGIS-based tests.
-
-    Returns:
-        callable: A function that accepts a vector layer and WKT geometries tuple.
-
-    The returned function signature:
-        add_wkt_features_to_layer(vector_layer: QgsVectorLayer, wkt_geometries: tuple[str, ...]) -> None
-
-    Args (for the returned function):
-        vector_layer (QgsVectorLayer): The target vector layer to add features to.
-        wkt_geometries (tuple[str, ...]): Tuple of WKT geometry strings to be
-            converted to QgsGeometry objects and added as features.
-
-    Example:
-        ```python
-        def test_layer_features(add_features):
-            layer = QgsVectorLayer("Point", "test_layer", "memory")
-            geometries = ("POINT(0 0)", "POINT(1 1)", "POINT(2 2)")
-            add_features(layer, geometries)
-            assert layer.featureCount() == 3
-        ```
-    """
-
     def add_wkt_features_to_layer(vector_layer: QgsVectorLayer, wkt_geometries: tuple[str, ...]) -> None:
         data_provider: QgsVectorDataProvider = vector_layer.dataProvider()
         for wkt_geometry in wkt_geometries:
@@ -219,25 +221,6 @@ def add_features():
 
 @pytest.fixture(scope="module")
 def converter():
-    """
-    Pytest fixture that provides a WKT to polygon geometry converter function.
-
-    This session-scoped fixture returns a function that converts Well-Known Text (WKT)
-    strings into QGIS polygon geometry coordinate structures. The converter handles
-    both single polygons and multipolygons.
-
-    Returns:
-        A function that takes a WKT string and returns polygon coordinates as:
-        - For single polygon: list[list[QgsPointXY]] - rings of coordinates
-        - For multipolygon: list[list[list[QgsPointXY]]] - polygons containing rings
-
-    Example:
-        def test_polygon_conversion(converter):
-            result = converter("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))")
-            assert len(result) == 1  # One ring
-            assert len(result[0]) == 5  # Five points in the ring
-    """
-
     def wkt_to_polygon_geometry(wkt: str) -> list[list[QgsPointXY]] | list[list[list[QgsPointXY]]]:
         geom: QgsGeometry = QgsGeometry.fromWkt(wkt)
         if geom.isMultipart():


### PR DESCRIPTION
## Summary
- **Behavior fix:** Move the `no_multi` short-circuit ahead of the closest-line lookup so an empty line layer no longer raises when `Skip Multipolygons` is enabled. Covered by a new regression test in `tests/test_main_functionality.py`.
- **Cleanup:** Strip verbose Sphinx-style docstrings across `src/` modules in favor of type hints + named identifiers. Net diff: 532 deletions / 128 insertions.
- **Caching:** `Polygon.center_xy` and `PolygonsParallelToLine.line_layer` are now `cached_property`; `LineLayer.__init__` no longer iterates the source twice.
- **Dead code:** Drop `sys.path` manipulation in `plugin.py`, unused `Line.feature` / `Line.calc_distance`, and the redundant `*args/**kwargs` on `Provider` overrides.
- **Compatibility:** Bump `qgisMinimumVersion` from `3.0` to `3.22` to match the actually-supported APIs.
- **Tooling:** Parameterize `Makefile` (image/container names, idempotent `run`/`clean`, coverage scoped to `src/`); update `DEVELOPMENT.md` to use generic clone paths; widen ruff `D103` ignore globally and narrow per-file lists.
- **Docs:** Refresh `README.md` algorithm description (centroid-based selection, multipolygon rotation behavior, `_rotated` semantics).

Note: until #89 merges, this PR's diff includes the `CLAUDE.md` commit as well — it will simplify once #89 lands.

## Test plan
- [ ] `make test` (full pytest suite, including the new `test_no_multi_skips_multipolygons_when_line_layer_empty`)
- [ ] Sanity-check the processing UI in QGIS for the rotation pipeline
- [ ] Confirm the `Skip Multipolygons` toggle works against an empty line layer