### PR TITLE
Automate releases via tag-triggered qgis-plugin-ci workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Release
+permissions:
+  contents: write
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with: {fetch-depth: 0}
+    - run: make build
+    - run: make run
+    - run: make install
+    - run: make test
+    - if: always()
+      run: make clean
+
+  publish:
+    name: Publish to plugins.qgis.org
+    needs: [tests]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with: {fetch-depth: 0}
+    - uses: actions/setup-python@v6
+      with: {python-version: '3.12'}
+    - run: pip install qgis-plugin-ci==2.10.0
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OSGEO_USERNAME: ${{ secrets.OSGEO_USERNAME }}
+        OSGEO_PASSWORD: ${{ secrets.OSGEO_PASSWORD }}
+      run: |
+        qgis-plugin-ci release "${GITHUB_REF_NAME}" \
+          --github-token   "${GITHUB_TOKEN}" \
+          --osgeo-username "${OSGEO_USERNAME}" \
+          --osgeo-password "${OSGEO_PASSWORD}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.coverage
 /coverage.xml
 /junit.xml
+.DS_Store
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [1.2.0] - 2026-06-01
+- Enhance polygon rotation logic and geometry validation
+- Fix `no_multi` regression
+- Test against QGIS 4.0
+- Automate releases via tag-triggered `qgis-plugin-ci` pipeline
+
+## [1.1.0] - 2025-06-13
+- Enhance UI text readability
+- Skip rotation when an angle is close to zero to avoid unnecessary operations and wrong "_rotated" values
+- Handle polygon vertex duplicates and internal rings properly
+- Update test cases to cover new edge cases
+
+## [1.0.0] - 2023-11-19
+- Add QGIS 3 support
+- Add tests
+- Fix bugs
+
+## [0.3.0] - 2017-04-05
+- Migrate to Processing algorithms; full refactoring
+- Major performance improvements
+- Add option to write all or only selected polygons to the new layer
+- Add option to rotate or skip multipolygons
+- Process each polyline of a multipolyline as a separate line
+- Avoid duplicating the "_rotated" field if it already exists
+
+## [0.2.1] - 2017-03-14
+- Add Russian and Ukrainian translations
+
+## [0.2.0] - 2016-04-07
+- Major performance improvements via spatial index and built-in PyQGIS methods
+- Add progress bar
+- Add option to rotate only selected polygons
+- Add "rotated" field to the polygon layer (value `1` for rotated polygons)
+- New icon
+- English-only code comments
+
+## [0.1.0] - 2016-03-31
+- Initial release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-QGIS Processing plugin `PolygonsParallelToLine` (id `pptl`) — rotates polygons to align with the nearest line feature. Distributed via the QGIS plugin portal. Version lives in **both** `PolygonsParallelToLine/metadata.txt` (`version=`) and `pyproject.toml` (`version =`) — keep them in sync when bumping.
+QGIS Processing plugin `PolygonsParallelToLine` (id `pptl`) — rotates polygons to align with the nearest line feature. Distributed via the QGIS plugin portal. Releases are tag-driven via `.github/workflows/release.yaml`; `qgis-plugin-ci` patches `metadata.txt`'s `version=` and `changelog=` in the zip at build time. In-repo `version=` strings are placeholders (`0.0.0`).
 
 ## Environment
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,11 +54,21 @@ These instructions are specific to PyCharm.
     - Value: `<absolute/path/to/repo>` (the absolute path to your local clone of this repository)
 5. To reload the plugin, use the "Plugin Reloader" plugin.
 
-## Add a New Plugin Version to QGIS
+## Releasing a New Plugin Version
 
-1. Run:
+1. Move the entries under `## [Unreleased]` in `CHANGELOG.md` to a new `## [X.Y.Z] - YYYY-MM-DD` section. `qgis-plugin-ci` requires a 3-part `MAJOR.MINOR.PATCH` version — `## [1.2]` will be silently ignored and the published changelog will be empty.
+2. Commit and push to `main`.
+3. Tag and push (3-part versions only):
    ```shell
-   zip -r pptl.zip PolygonsParallelToLine/ -x "*.DS_Store" "__MACOSX" "*/__pycache__/*" "*.pyc" "*.pyo" "*~" "*.bak"
+   git tag X.Y.Z
+   git push origin X.Y.Z
    ```
-2. Open https://plugins.qgis.org/plugins/PolygonsParallelToLine/version/add/
-3. Upload `pptl.zip`
+4. The `Release` workflow (`.github/workflows/release.yaml`) runs the tests, then publishes to plugins.qgis.org and creates a GitHub Release with the `.zip` attached.
+
+Required GitHub Secrets (one-time setup, repo Settings → Secrets and variables → Actions):
+- `OSGEO_USERNAME` — your plugins.qgis.org account username
+- `OSGEO_PASSWORD` — your plugins.qgis.org account password
+
+(`GITHUB_TOKEN` is provided automatically by Actions.)
+
+For a staged/experimental release, use a 3-part pre-release tag suffix (e.g. `1.2.0-rc1`). The portal will list it as experimental. A 2-part form like `1.2-rc1` is not detected as a pre-release by `qgis-plugin-ci` and will be published as stable.

--- a/PolygonsParallelToLine/metadata.txt
+++ b/PolygonsParallelToLine/metadata.txt
@@ -2,7 +2,7 @@
 name=Polygons Parallel to Line
 qgisMinimumVersion=3.22
 description=This plugin rotates polygons parallel to lines
-version=1.1
+version=0.0.0
 author=Andrii Liekariev
 email=elfpkck@gmail.com
 hasProcessingProvider=yes
@@ -12,11 +12,7 @@ about=This plugin rotates polygons to be parallel to the nearest line segment. I
 tracker=https://github.com/Elfpkck/polygons_parallel_to_line/issues
 repository=https://github.com/Elfpkck/polygons_parallel_to_line
 
-changelog=
-    - Enhance UI text readability
-    - Skip rotation when an angle is close to zero to avoid unnecessary operations and wrong "_rotated" values
-    - Handle polygon vertex duplicates and internal rings properly
-    - Update test cases to cover new edge cases
+changelog=See CHANGELOG.md
 
 tags=polygon, line, vector, parallel, rotating
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = "GPL-2.0-or-later"
 name = "polygons-parallel-to-line"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "1.1"
+version = "0.0.0"
 
 [tool.coverage.report]
 exclude_also = [
@@ -34,6 +34,11 @@ follow_imports = "silent"
 ignore_missing_imports = false
 namespace_packages = true
 warn_return_any = true
+
+[tool.qgis-plugin-ci]
+github_organization_slug = "Elfpkck"
+plugin_path = "PolygonsParallelToLine"
+project_slug = "polygons_parallel_to_line"
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "polygons-parallel-to-line"
-version = "1.1"
+version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pre-commit" },


### PR DESCRIPTION
## Summary
- Replace the manual zip-and-upload release process with a tag-driven GitHub Actions workflow (`.github/workflows/release.yaml`). Tags matching `X.Y.Z` (or `X.Y.Z-*` for pre-releases) trigger tests, then publish the plugin to plugins.qgis.org and create a GitHub Release with the `.zip` attached.
- Add `CHANGELOG.md` in Keep a Changelog format with backfilled version history (0.1.0 → 1.1.0) from the QGIS portal and GitHub releases. `qgis-plugin-ci` patches the per-version section into the published zip's `metadata.txt` `changelog=` field.
- Set in-repo `version=` to `0.0.0` in both `metadata.txt` and `pyproject.toml` — `qgis-plugin-ci` patches the real version into the zip from the tag name at build time.
- Update `CLAUDE.md` and `DEVELOPMENT.md` to document the new release flow (3-part semver required; `1.2` would be silently dropped).

## Test plan
- [ ] Confirm `OSGEO_USERNAME` and `OSGEO_PASSWORD` secrets are set in repo Settings → Secrets and variables → Actions
- [ ] Merge to `main`
- [ ] Tag `1.2.0` from `main` and push; watch the `Release` workflow
  - [ ] `Unit Tests` job passes
  - [ ] `Publish to plugins.qgis.org` job uploads successfully
  - [ ] GitHub Release is created with the `.zip` attached
  - [ ] Plugin appears as v1.2.0 at https://plugins.qgis.org/plugins/PolygonsParallelToLine/
  - [ ] Downloaded `.zip` has `version=1.2.0` and the `[1.2.0]` changelog section patched into `metadata.txt`