### PR TITLE
Create GitHub Release before invoking qgis-plugin-ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,15 @@ jobs:
     - uses: actions/setup-python@v6
       with: {python-version: '3.12'}
     - run: pip install qgis-plugin-ci==2.10.0
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+          gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes --prerelease
+        else
+          gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
+        fi
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The 1.2.0 release failed in the `Publish to plugins.qgis.org` job because `qgis-plugin-ci release` queries the GitHub Release by tag (to determine prerelease status) and fails with `GithubReleaseNotFound` if it doesn't exist yet (see [run 26751390918](https://github.com/Elfpkck/polygons_parallel_to_line/actions/runs/26751390918)). Recovered by creating the release manually + rerunning.

This PR adds a `Create GitHub Release` step before the `Release` step so the workflow self-heals on future tags. Prerelease suffix (`X.Y.Z-rc1`) is detected and passed to `gh release create --prerelease` so the QGIS portal flags it as experimental. Notes are auto-generated from merged PRs (`--generate-notes`); the CHANGELOG section is still patched into the published `.zip` by `qgis-plugin-ci`.

## Test plan
- [ ] Merge to `main`
- [ ] On the next tag push, confirm the `Create GitHub Release` step succeeds and the `Release` step proceeds without manual intervention
- [ ] For a prerelease tag like `X.Y.Z-rc1`, confirm the GitHub Release is marked as prerelease and the QGIS portal lists it as experimental