### PR TITLE
Make release workflow re-runnable and clean up on failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,14 +32,21 @@ jobs:
       with: {python-version: '3.12'}
     - run: pip install qgis-plugin-ci==2.10.0
     - name: Create GitHub Release
+      id: create_release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+          echo "Release ${GITHUB_REF_NAME} already exists, skipping creation."
+          echo "created=false" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
         if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
           gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes --prerelease
         else
           gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
         fi
+        echo "created=true" >> "${GITHUB_OUTPUT}"
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,3 +57,8 @@ jobs:
           --github-token   "${GITHUB_TOKEN}" \
           --osgeo-username "${OSGEO_USERNAME}" \
           --osgeo-password "${OSGEO_PASSWORD}"
+    - name: Delete orphan release on failure
+      if: failure() && steps.create_release.outputs.created == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release delete "${GITHUB_REF_NAME}" --yes


### PR DESCRIPTION
## Summary
- Skip `gh release create` when a release for the tag already exists, so re-running the publish job (e.g. after a transient OSGEO upload error) no longer aborts on `release already exists`.
- Track whether *this* run created the release via a `created=true` step output, and on job failure delete the release only when we created it — preventing partial publishes from leaving an empty GitHub Release with no plugin zip attached.
- The tag is preserved on cleanup so a re-run proceeds normally.

## Test plan
- [ ] Trigger the workflow against a tag where the release does not yet exist → step creates the release, sets `created=true`, `qgis-plugin-ci release` uploads the asset.
- [ ] Re-run the publish job for an already-released tag → `gh release view` succeeds, step logs `already exists, skipping creation`, sets `created=false`, and the run continues into `qgis-plugin-ci release`.
- [ ] Simulate a failure in the `Release` step on a freshly-created release → cleanup step fires and deletes the release; the tag remains.
- [ ] Simulate a failure in the `Release` step on a pre-existing release (re-run path) → cleanup step is skipped (`created=false`); pre-existing release is preserved.