### PR TITLE
Mark plugin QGIS 4 compatible and scope Qt enums for PyQt6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+- Mark the plugin as QGIS 4 compatible (`qgisMaximumVersion=4.99`) and fully scope PyQt6-required Qt enums in the map tool and settings dialog so they work on QGIS 4 / Qt 6
 
 ## [2.0.0] - 2026-06-06
 - Add an interactive map tool: pick a reference line on the canvas, then click — or drag a rectangle — to rotate individual line/polygon features (or every feature in the rectangle across editable visible layers) parallel to it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ QGIS Processing plugin `PolygonsParallelToLine` (id `pptl`) — rotates polygons
 
 Tests require QGIS Python bindings, so everything runs inside the `qgis_pptl` Docker container (image `qgis/qgis:4.0.0`, repo mounted at `/pptl`). The host `.venv` is *shadowed* inside the container by an anonymous volume — host installs are not visible to the container.
 
-See `Makefile` for build/run/install/test targets (all `make` invocations assume the container is running).
+See `Makefile` for build/run/install/test targets (all `make` invocations assume the container is running). Use `make test-all` as the default for running the suite — it covers both the unit tests and the `perf`-marked smoke test in one invocation. Reach for the narrower `make test` / `make test-perf` only when intentionally scoping to one slice.
 
 Single test inside the container:
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ QGIS_VERSION ?= 4.0.0
 IMAGE := qgis-for-pptl:$(QGIS_VERSION)
 CONTAINER := qgis_pptl
 
-.PHONY: build run install install-dev test test-coverage test-perf stop clean
+.PHONY: build run install install-dev test test-coverage test-perf test-all stop clean
 
 build:
 	DOCKER_SCAN_SUGGEST=false docker build -t $(IMAGE) -f Dockerfile .
@@ -36,6 +36,9 @@ test-coverage:
 
 test-perf:
 	docker exec $(CONTAINER) sh -c "cd /pptl && uv run --no-dev pytest /pptl/tests -m perf --qgis_disable_gui"
+
+test-all:
+	docker exec $(CONTAINER) sh -c "cd /pptl && uv run --no-dev pytest /pptl/tests -o 'addopts=' --qgis_disable_gui"
 
 stop:
 	-docker stop $(CONTAINER)

--- a/PolygonsParallelToLine/metadata.txt
+++ b/PolygonsParallelToLine/metadata.txt
@@ -1,6 +1,7 @@
 [general]
 name=Polygons Parallel to Line
 qgisMinimumVersion=3.22
+qgisMaximumVersion=4.99
 description=Rotates polygons and lines to be parallel to a reference line, in batch (Processing) or interactively from the map canvas
 version=0.0.0
 author=Andrii Liekariev

--- a/PolygonsParallelToLine/src/map_tool.py
+++ b/PolygonsParallelToLine/src/map_tool.py
@@ -79,7 +79,7 @@ class ParallelToLineMapTool(QgsMapToolIdentifyFeature):
 
     def activate(self) -> None:
         super().activate()
-        self.setCursor(Qt.CrossCursor)
+        self.setCursor(Qt.CursorShape.CrossCursor)
         self._show_message("Click or drag-rectangle on a line to set the reference.", Qgis.Info)
 
     def deactivate(self) -> None:
@@ -88,7 +88,7 @@ class ParallelToLineMapTool(QgsMapToolIdentifyFeature):
         super().deactivate()
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
-        if event.key() == Qt.Key_Escape:
+        if event.key() == Qt.Key.Key_Escape:
             if self._is_dragging:
                 self._cancel_drag()
                 return
@@ -101,7 +101,7 @@ class ParallelToLineMapTool(QgsMapToolIdentifyFeature):
         super().keyPressEvent(event)
 
     def canvasPressEvent(self, event: QgsMapMouseEvent) -> None:
-        if event.button() != Qt.LeftButton:
+        if event.button() != Qt.MouseButton.LeftButton:
             return
         self._drag_start_pos = event.pos()
         self._drag_start_point = self.toMapCoordinates(event.pos())
@@ -118,13 +118,13 @@ class ParallelToLineMapTool(QgsMapToolIdentifyFeature):
         self._update_selection_band(self.toMapCoordinates(event.pos()))
 
     def canvasReleaseEvent(self, event: QgsMapMouseEvent) -> None:
-        if event.button() == Qt.RightButton:
+        if event.button() == Qt.MouseButton.RightButton:
             self._cancel_drag()
             self._clear_reference()
             self._show_message("Reference cleared. Click a line feature to set a new reference.", Qgis.Info)
             return
 
-        if event.button() != Qt.LeftButton:
+        if event.button() != Qt.MouseButton.LeftButton:
             return
 
         was_dragging = self._is_dragging

--- a/PolygonsParallelToLine/src/provider.py
+++ b/PolygonsParallelToLine/src/provider.py
@@ -7,7 +7,7 @@ from qgis.core import QgsProcessingProvider
 from .algorithm import Algorithm
 
 if TYPE_CHECKING:
-    from PyQt5.QtGui import QIcon
+    from qgis.PyQt.QtGui import QIcon  # type: ignore[import-not-found]
 
 
 class Provider(QgsProcessingProvider):

--- a/PolygonsParallelToLine/src/settings_dialog.py
+++ b/PolygonsParallelToLine/src/settings_dialog.py
@@ -39,7 +39,7 @@ class MapToolSettingsDialog(QDialog):
         picking_layout.addWidget(self._pick_target_checkbox)
         picking_group.setLayout(picking_layout)
 
-        button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         button_box.accepted.connect(self._apply)
         button_box.rejected.connect(self.reject)
 


### PR DESCRIPTION
- Declare qgisMaximumVersion=4.99 in metadata.txt
- Fully scope Qt enums (Qt.CursorShape, Qt.Key, Qt.MouseButton, QDialogButtonBox.StandardButton) in map_tool and settings_dialog
- Import QIcon via qgis.PyQt.QtGui so the type hint resolves under both PyQt5 and PyQt6
- Add test-all Makefile target to run unit + perf suites in one pass