### PR TITLE
Rename repo references to parallelizer

### DIFF
--- a/PolygonsParallelToLine/metadata.txt
+++ b/PolygonsParallelToLine/metadata.txt
@@ -8,16 +8,16 @@ author=Andrii Liekariev
 email=elfpkck@gmail.com
 hasProcessingProvider=yes
 
-about=This plugin rotates polygons (and lines) to be parallel to the nearest reference segment; the reference can be a line or polygon layer (polygon boundary rings are treated as polylines). Two entry points are provided: a batch Processing algorithm that operates on whole layers, and an interactive map tool that lets you pick a reference line or polygon feature on the canvas and then click — or drag-rectangle — individual line/polygon features to rotate them in place. It is useful when working with streets and buildings. Before using the plugin, we strongly recommend checking your data for geometric errors. A full description can be found at https://elfpkck.github.io/polygons_parallel_to_line/
+about=This plugin rotates polygons (and lines) to be parallel to the nearest reference segment; the reference can be a line or polygon layer (polygon boundary rings are treated as polylines). Two entry points are provided: a batch Processing algorithm that operates on whole layers, and an interactive map tool that lets you pick a reference line or polygon feature on the canvas and then click — or drag-rectangle — individual line/polygon features to rotate them in place. It is useful when working with streets and buildings. Before using the plugin, we strongly recommend checking your data for geometric errors. A full description can be found at https://elfpkck.github.io/parallelizer/
 
-tracker=https://github.com/Elfpkck/polygons_parallel_to_line/issues
-repository=https://github.com/Elfpkck/polygons_parallel_to_line
+tracker=https://github.com/Elfpkck/parallelizer/issues
+repository=https://github.com/Elfpkck/parallelizer
 
 changelog=See CHANGELOG.md
 
 tags=polygon, line, vector, parallel, rotating, interactive, map tool
 
-homepage=https://elfpkck.github.io/polygons_parallel_to_line/
+homepage=https://elfpkck.github.io/parallelizer/
 category=Vector
 icon=icons/icon.png
 

--- a/PolygonsParallelToLine/src/algorithm.py
+++ b/PolygonsParallelToLine/src/algorithm.py
@@ -53,7 +53,7 @@ class Algorithm(QgsProcessingAlgorithm):
         return "Rotates polygons parallel to features in a reference layer (line or polygon)."
 
     def helpUrl(self) -> str:  # noqa: N802
-        return "https://elfpkck.github.io/polygons_parallel_to_line/"
+        return "https://elfpkck.github.io/parallelizer/"
 
     def initAlgorithm(self, config: dict | None = None) -> None:  # noqa: N802
         self.addParameter(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![PR Validation](https://github.com/Elfpkck/polygons_parallel_to_line/actions/workflows/test.yaml/badge.svg?event=pull_request)](https://github.com/Elfpkck/polygons_parallel_to_line/actions/workflows/test.yaml)
-[![codecov](https://codecov.io/gh/Elfpkck/polygons_parallel_to_line/graph/badge.svg?token=QEHFI3XE08)](https://codecov.io/gh/Elfpkck/polygons_parallel_to_line)
+[![PR Validation](https://github.com/Elfpkck/parallelizer/actions/workflows/test.yaml/badge.svg?event=pull_request)](https://github.com/Elfpkck/parallelizer/actions/workflows/test.yaml)
+[![codecov](https://codecov.io/gh/Elfpkck/parallelizer/graph/badge.svg?token=QEHFI3XE08)](https://codecov.io/gh/Elfpkck/parallelizer)
 
 [![QGIS](https://qgis.github.io/qgis-uni-navigation/logo.svg)](https://qgis.org)
 
@@ -182,8 +182,8 @@ This project is licensed under the [GNU General Public License v2.0 or later](LI
 
 ## Support
 
-- 🐛 [Report Issues](https://github.com/Elfpkck/polygons_parallel_to_line/issues)
-- 💬 [Discussion Forum](https://github.com/Elfpkck/polygons_parallel_to_line/discussions)
+- 🐛 [Report Issues](https://github.com/Elfpkck/parallelizer/issues)
+- 💬 [Discussion Forum](https://github.com/Elfpkck/parallelizer/discussions)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 description = ""
 license = "GPL-2.0-or-later"
-name = "polygons-parallel-to-line"
+name = "parallelizer"
 readme = "README.md"
 requires-python = ">=3.9"
 version = "0.0.0"
@@ -42,7 +42,7 @@ markers = ["perf: performance smoke tests (skipped by default; run with `-m perf
 [tool.qgis-plugin-ci]
 github_organization_slug = "Elfpkck"
 plugin_path = "PolygonsParallelToLine"
-project_slug = "polygons_parallel_to_line"
+project_slug = "parallelizer"
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -20,7 +20,7 @@ def test_algorithm_initialization(algorithm_instance):
     assert algorithm_instance.shortHelpString() == (
         "Rotates polygons parallel to features in a reference layer (line or polygon)."
     )
-    assert algorithm_instance.helpUrl() == "https://elfpkck.github.io/polygons_parallel_to_line/"
+    assert algorithm_instance.helpUrl() == "https://elfpkck.github.io/parallelizer/"
 
 
 def test_algorithm_create_instance(algorithm_instance):

--- a/uv.lock
+++ b/uv.lock
@@ -210,25 +210,7 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
-]
-
-[[package]]
-name = "pluggy"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "polygons-parallel-to-line"
+name = "parallelizer"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
@@ -254,6 +236,24 @@ requires-dist = [
 dev = [
     { name = "pydevd-pycharm" },
     { name = "ruff", specifier = ">=0.15.15" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update repository URLs, package name, and project_slug to match the new parallelizer repo name.