### PR TITLE
Lowercase GitHub username in repo links and configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 10
     reviewers:
-      - "Elfpkck"
+      - "elfpkck"
     assignees:
-      - "Elfpkck"
+      - "elfpkck"
     labels:
       - "ci"
 
@@ -21,9 +21,9 @@ updates:
       time: "03:10"
       timezone: "UTC"
     reviewers:
-      - "Elfpkck"
+      - "elfpkck"
     assignees:
-      - "Elfpkck"
+      - "elfpkck"
     labels:
       - "ci"
 
@@ -34,9 +34,9 @@ updates:
       time: "03:15"
       timezone: "UTC"
     reviewers:
-      - "Elfpkck"
+      - "elfpkck"
     assignees:
-      - "Elfpkck"
+      - "elfpkck"
     labels:
       - "dependencies"
     allow:

--- a/PolygonsParallelToLine/metadata.txt
+++ b/PolygonsParallelToLine/metadata.txt
@@ -10,8 +10,8 @@ hasProcessingProvider=yes
 
 about=This plugin rotates polygons (and lines) to be parallel to the nearest reference segment; the reference can be a line or polygon layer (polygon boundary rings are treated as polylines). Two entry points are provided: a batch Processing algorithm that operates on whole layers, and an interactive map tool that lets you pick a reference line or polygon feature on the canvas and then click — or drag-rectangle — individual line/polygon features to rotate them in place. It is useful when working with streets and buildings. Before using the plugin, we strongly recommend checking your data for geometric errors. A full description can be found at https://elfpkck.github.io/parallelizer/
 
-tracker=https://github.com/Elfpkck/parallelizer/issues
-repository=https://github.com/Elfpkck/parallelizer
+tracker=https://github.com/elfpkck/parallelizer/issues
+repository=https://github.com/elfpkck/parallelizer
 
 changelog=See CHANGELOG.md
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![PR Validation](https://github.com/Elfpkck/parallelizer/actions/workflows/test.yaml/badge.svg?event=pull_request)](https://github.com/Elfpkck/parallelizer/actions/workflows/test.yaml)
-[![codecov](https://codecov.io/gh/Elfpkck/parallelizer/graph/badge.svg?token=QEHFI3XE08)](https://codecov.io/gh/Elfpkck/parallelizer)
+[![PR Validation](https://github.com/elfpkck/parallelizer/actions/workflows/test.yaml/badge.svg?event=pull_request)](https://github.com/elfpkck/parallelizer/actions/workflows/test.yaml)
+[![codecov](https://codecov.io/gh/elfpkck/parallelizer/graph/badge.svg?token=QEHFI3XE08)](https://codecov.io/gh/elfpkck/parallelizer)
 
 [![QGIS](https://qgis.github.io/qgis-uni-navigation/logo.svg)](https://qgis.org)
 
@@ -182,19 +182,19 @@ This project is licensed under the [GNU General Public License v2.0 or later](LI
 
 ## Support
 
-- 🐛 [Report Issues](https://github.com/Elfpkck/parallelizer/issues)
-- 💬 [Discussion Forum](https://github.com/Elfpkck/parallelizer/discussions)
+- 🐛 [Report Issues](https://github.com/elfpkck/parallelizer/issues)
+- 💬 [Discussion Forum](https://github.com/elfpkck/parallelizer/discussions)
 
 ---
 
 **Made with ❤️ for the QGIS community**
 
 <!-- Image References -->
-[intro]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/intro.gif
-[install]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/install.gif
-[open]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/open.gif
-[default_usage]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/default_usage.gif
-[_rotated]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/_rotated.png
-[distance]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/distance.gif
-[angle]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/angle.gif
-[by_longest]: https://raw.githubusercontent.com/Elfpkck/pptl_images/refs/heads/master/by_longest.gif
+[intro]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/intro.gif
+[install]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/install.gif
+[open]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/open.gif
+[default_usage]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/default_usage.gif
+[_rotated]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/_rotated.png
+[distance]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/distance.gif
+[angle]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/angle.gif
+[by_longest]: https://raw.githubusercontent.com/elfpkck/pptl_images/refs/heads/master/by_longest.gif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ addopts = "-m 'not perf'"
 markers = ["perf: performance smoke tests (skipped by default; run with `-m perf`)"]
 
 [tool.qgis-plugin-ci]
-github_organization_slug = "Elfpkck"
+github_organization_slug = "elfpkck"
 plugin_path = "PolygonsParallelToLine"
 project_slug = "parallelizer"
 


### PR DESCRIPTION
Normalize Elfpkck → elfpkck across dependabot reviewers/assignees, metadata.txt tracker/repository URLs, README badges and image links, and qgis-plugin-ci github_organization_slug to match the canonical GitHub login.