### PR TITLE
Add local preview setup for the GitHub Pages site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 /junit.xml
 .DS_Store
 __pycache__/
+/_site/
+/.jekyll-cache/
+/.jekyll-metadata
+/Gemfile.lock
+/vendor/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,3 +72,23 @@ Required GitHub Secrets (one-time setup, repo Settings → Secrets and variables
 (`GITHUB_TOKEN` is provided automatically by Actions.)
 
 For a staged/experimental release, use a 3-part pre-release tag suffix (e.g. `1.2.0-rc1`). The portal will list it as experimental. A 2-part form like `1.2-rc1` is not detected as a pre-release by `qgis-plugin-ci` and will be published as stable.
+
+## Previewing the GitHub Pages Site Locally
+
+The project page (`_config.yml`) is served by GitHub Pages with the `jekyll-theme-midnight` theme. To preview the site or trial other themes locally:
+
+1. Install Ruby 3.1. The `github-pages` gem pins Jekyll 3.9 / Liquid 4.0.3, which calls `String#tainted?` — removed in Ruby 3.2 — so newer Rubies will not work.
+    ```shell
+    brew install ruby@3.1
+    echo 'export PATH="/opt/homebrew/opt/ruby@3.1/bin:$PATH"' >> ~/.zshrc
+    exec zsh
+    ```
+2. Install the bundled gems and start the server:
+    ```shell
+    bundle install
+    bundle exec jekyll serve
+    ```
+    The site is served at http://127.0.0.1:4000.
+3. To try a different theme, stop the server (Ctrl-C), change `theme:` in `_config.yml`, and restart — Jekyll watches content but not config. The `Gemfile` already pulls in every GitHub-supported theme (`architect`, `cayman`, `dinky`, `hacker`, `leap-day`, `merlot`, `midnight`, `minimal`, `modernist`, `primer`, `slate`, `tactile`, `time-machine`).
+
+The `Gemfile` also lists several stdlib gems (`csv`, `bigdecimal`, `base64`, `logger`, `mutex_m`, `ostruct`, `drb`, `webrick`) that were promoted out of Ruby's default gem set in 3.0–3.4 and are still required by Jekyll 3.9 / its dependencies.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+
+# Ruby 3.0–3.4 moved these out of the default gems; Jekyll 3.9 still needs them declared.
+gem "csv"
+gem "bigdecimal"
+gem "base64"
+gem "logger"
+gem "mutex_m"
+gem "ostruct"
+gem "drb"
+gem "webrick"


### PR DESCRIPTION
Lets contributors trial themes and review page edits before pushing.